### PR TITLE
Improve get_apikey method and its tests

### DIFF
--- a/autoextract/apikey.py
+++ b/autoextract/apikey.py
@@ -11,10 +11,14 @@ class NoApiKey(Exception):
 
 def get_apikey(key: Optional[str] = None) -> str:
     """ Return API key, probably loading it from an environment variable """
-    if key is not None:
-        return key
-    try:
-        return os.environ[ENV_VARIABLE]
-    except KeyError:
+    if not key:
+        try:
+            key = os.environ[ENV_VARIABLE]
+        except KeyError:
+            pass
+
+    if not key:
         raise NoApiKey("API key not found. Please set {} "
                        "environment variable or pass".format(ENV_VARIABLE))
+
+    return key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,20 @@ import os
 from autoextract.apikey import ENV_VARIABLE
 
 
-@pytest.fixture()
-def autoextract_env_variable():
-    _FAKE_KEY = 'APIKEY'
+def fake_env(key):
     old_env = os.environ.copy()
-    os.environ[ENV_VARIABLE] = _FAKE_KEY
+    os.environ[ENV_VARIABLE] = key
     try:
-        yield _FAKE_KEY
+        yield key
     finally:
         os.environ = old_env
+
+
+@pytest.fixture()
+def autoextract_env_variable():
+    yield from fake_env('APIKEY')
+
+
+@pytest.fixture()
+def autoextract_blank_env_variable():
+    yield from fake_env('')

--- a/tests/test_apikey.py
+++ b/tests/test_apikey.py
@@ -9,6 +9,6 @@ def test_get_apikey(autoextract_env_variable):
     assert get_apikey() == autoextract_env_variable
 
 
-def test_get_apikey_missing():
+def test_get_apikey_missing(autoextract_blank_env_variable):
     with pytest.raises(NoApiKey):
         get_apikey()


### PR DESCRIPTION
This pull request:

- avoid problems when executing tests on local environment with populated variables
- avoid problems when environment variables are undefined or blank strings