### PR TITLE
Retry of Downloader error: internal

### DIFF
--- a/autoextract/aio/errors.py
+++ b/autoextract/aio/errors.py
@@ -86,6 +86,7 @@ _RETRIABLE_ERR_MSGS = [
     "Downloader error: 50",
     "Downloader error: GlobalTimeoutError",
     "Downloader error: ConnectionResetByPeer",
+    "Downloader error: internal',
     "Proxy error: banned",
     "Proxy error: internal_error",
     "Proxy error: nxdomain",

--- a/autoextract/aio/errors.py
+++ b/autoextract/aio/errors.py
@@ -86,7 +86,7 @@ _RETRIABLE_ERR_MSGS = [
     "Downloader error: 50",
     "Downloader error: GlobalTimeoutError",
     "Downloader error: ConnectionResetByPeer",
-    "Downloader error: internal',
+    "Downloader error: internal",
     "Proxy error: banned",
     "Proxy error: internal_error",
     "Proxy error: nxdomain",


### PR DESCRIPTION
In many cases, this is how banning issues are flagged.