### PR TITLE
--disable-ssl-check option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+TBR:
+------------------
+
+* --disable-ssl-check option to disable ssl verification.
+
 0.7.0 (2021-02-10)
 ------------------
 

--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -24,9 +24,9 @@ logger = logging.getLogger('autoextract')
 
 
 async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
-              api_key=None, api_endpoint=None, max_query_error_retries=0):
+              api_key=None, api_endpoint=None, max_query_error_retries=0, disable_ssl=False):
     agg_stats = AggStats()
-    async with create_session(connection_pool_size=n_conn) as session:
+    async with create_session(connection_pool_size=n_conn, disable_ssl=disable_ssl) as session:
         result_iter = request_parallel_as_completed(
             query=query,
             n_conn=n_conn,
@@ -127,6 +127,8 @@ if __name__ == '__main__':
                         "success rate at the cost of more requests being "
                         "performed. It is recommended if you are interested "
                         "in a higher success rate.")
+    p.add_argument("--disable-ssl-check", action="store_true",
+                   help="Disable SSL certificate validation in HTTPS requests")
     args = p.parse_args()
     logging.basicConfig(level=getattr(logging, args.loglevel))
 
@@ -146,6 +148,7 @@ if __name__ == '__main__':
                stop_on_errors=False,
                api_key=args.api_key,
                api_endpoint=args.api_endpoint,
-               max_query_error_retries=args.max_query_error_retries)
+               max_query_error_retries=args.max_query_error_retries,
+               disable_ssl=args.disable_ssl_check)
     loop.run_until_complete(coro)
     loop.close()

--- a/autoextract/__main__.py
+++ b/autoextract/__main__.py
@@ -24,9 +24,9 @@ logger = logging.getLogger('autoextract')
 
 
 async def run(query: Query, out, n_conn, batch_size, stop_on_errors=False,
-              api_key=None, api_endpoint=None, max_query_error_retries=0, disable_ssl=False):
+              api_key=None, api_endpoint=None, max_query_error_retries=0, disable_cert_validation=False):
     agg_stats = AggStats()
-    async with create_session(connection_pool_size=n_conn, disable_ssl=disable_ssl) as session:
+    async with create_session(connection_pool_size=n_conn, disable_cert_validation=disable_cert_validation) as session:
         result_iter = request_parallel_as_completed(
             query=query,
             n_conn=n_conn,
@@ -127,8 +127,9 @@ if __name__ == '__main__':
                         "success rate at the cost of more requests being "
                         "performed. It is recommended if you are interested "
                         "in a higher success rate.")
-    p.add_argument("--disable-ssl-check", action="store_true",
-                   help="Disable SSL certificate validation in HTTPS requests")
+    p.add_argument("--disable-cert-validation", action="store_true",
+                   help="Disable TSL certificate validation in HTTPS requests. "
+                        "Any certificate will be accepted. Consider the security consequences.")
     args = p.parse_args()
     logging.basicConfig(level=getattr(logging, args.loglevel))
 
@@ -149,6 +150,6 @@ if __name__ == '__main__':
                api_key=args.api_key,
                api_endpoint=args.api_endpoint,
                max_query_error_retries=args.max_query_error_retries,
-               disable_ssl=args.disable_ssl_check)
+               disable_cert_validation=args.disable_cert_validation)
     loop.run_until_complete(coro)
     loop.close()

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -25,11 +25,11 @@ AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 60,
                                         sock_connect=10)
 
 
-def create_session(connection_pool_size=100, disable_ssl=False, **kwargs) -> aiohttp.ClientSession:
+def create_session(connection_pool_size=100, disable_cert_validation=False, **kwargs) -> aiohttp.ClientSession:
     """ Create a session with parameters suited for Zyte Automatic Extraction """
     kwargs.setdefault('timeout', AIO_API_TIMEOUT)
     if "connector" not in kwargs:
-        kwargs["connector"] = TCPConnector(limit=connection_pool_size, ssl=False if disable_ssl else None)
+        kwargs["connector"] = TCPConnector(limit=connection_pool_size, ssl=False if disable_cert_validation else None)
     return aiohttp.ClientSession(**kwargs)
 
 

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -25,11 +25,11 @@ AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 60,
                                         sock_connect=10)
 
 
-def create_session(connection_pool_size=100, **kwargs) -> aiohttp.ClientSession:
+def create_session(connection_pool_size=100, disable_ssl=False, **kwargs) -> aiohttp.ClientSession:
     """ Create a session with parameters suited for Zyte Automatic Extraction """
     kwargs.setdefault('timeout', AIO_API_TIMEOUT)
     if "connector" not in kwargs:
-        kwargs["connector"] = TCPConnector(limit=connection_pool_size)
+        kwargs["connector"] = TCPConnector(limit=connection_pool_size, ssl=False if disable_ssl else None)
     return aiohttp.ClientSession(**kwargs)
 
 


### PR DESCRIPTION
Some users are experiencing problems with the certificates on Windows. While I think the problem is that Windows certs are not up to date, anyway this is causing troubles to the users. As a scape hatch, this PR introduces the option `--disable-ssl-check`` to skip the problem by disabling SSL verification.

An alternative would have been to install our own certificates using `certifi`. But `aiohttp` guys decided [not to do so](https://github.com/aio-libs/aiohttp/issues/341) and neither should we: we should rely on OS certs instead of trying to pack the certificates ourselves. 