### PR TITLE
Add --timeout to the CLI, don't retry client timeout errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,12 @@ input queries before sending them to the API:
 
     python -m autoextract urls.txt --shuffle --page-type articles --output res.jl
 
+Some requests can take a lot of time to complete, so processing may be fast initially,
+but will slow down towards the end, while we wait for the last slow requests to complete.
+If this is undesireable, it's possible to set a smaller client timeout value,
+e.g. ``--timeout 120`` would cancel requests after 2 minutes without retrying them,
+which can be a good compromise between quality and processing speed.
+
 Run ``python -m autoextract --help`` to get description of all supported
 options.
 
@@ -138,6 +144,7 @@ Errors
 The following errors could happen while making requests:
 
 - Network errors
+- Client Timeout errors
 - `Request-level errors`_
     - Authentication failure
     - Malformed request
@@ -169,6 +176,7 @@ Retries
 By default, we will automatically retry Network and Request-level errors.
 You could also enable Query-level errors retries
 by specifying the ``--max-query-error-retries`` argument.
+Client Timeout errors are never retried.
 
 Enable Query-level retries to increase the success rate
 at the cost of more requests being performed

--- a/autoextract/aio/client.py
+++ b/autoextract/aio/client.py
@@ -25,12 +25,13 @@ AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 60,
                                         sock_connect=10)
 
 
-def create_session(connection_pool_size=100, disable_cert_validation=False, **kwargs) -> aiohttp.ClientSession:
+def create_session(connection_pool_size=100, disable_cert_validation=False, timeout=None, **kwargs) -> aiohttp.ClientSession:
     """ Create a session with parameters suited for Zyte Automatic Extraction """
-    kwargs.setdefault('timeout', AIO_API_TIMEOUT)
+    if timeout is None:
+        timeout = AIO_API_TIMEOUT
     if "connector" not in kwargs:
         kwargs["connector"] = TCPConnector(limit=connection_pool_size, ssl=False if disable_cert_validation else None)
-    return aiohttp.ClientSession(**kwargs)
+    return aiohttp.ClientSession(timeout=timeout, **kwargs)
 
 
 class Result(List[Dict]):

--- a/autoextract/aio/retry.py
+++ b/autoextract/aio/retry.py
@@ -4,7 +4,6 @@ Zyte Automatic Extraction retrying logic.
 
 TODO: add sync support; only autoextract.aio is supported at the moment.
 """
-import asyncio
 import logging
 
 from aiohttp import client_exceptions
@@ -29,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 
 _NETWORK_ERRORS = (
-    asyncio.TimeoutError,  # could happen while reading the response body
     client_exceptions.ClientResponseError,
     client_exceptions.ClientOSError,
     client_exceptions.ServerConnectionError,


### PR DESCRIPTION
Fixes https://github.com/zytedata/zyte-autoextract/issues/38

This PR adds ``--timeout`` argument to the CLI. Also it disables retries of client timeouts - else this defeats the purpose as we'd spend a lot of time retrying them. I think it's a fine change, but maybe I'm missing some use-case? With default timeout value, client timeouts shouldn't normally happen, unless there are some severe networking problems.

TODO:

- [x] more testing on realistic data
- [x] update README
- [ ] make it clear that timeout errors are usually billed, and count them as billed in the stats